### PR TITLE
Don't decode blocks starting outside mapped memory & undefined instea…

### DIFF
--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -47,7 +47,7 @@ namespace ARMeilleure.Decoders
             {
                 if (!visited.TryGetValue(blkAddress, out Block block))
                 {
-                    if (opsCount > MaxInstsPerFunction)
+                    if (opsCount > MaxInstsPerFunction || !memory.IsMapped((long)blkAddress))
                     {
                         return null;
                     }

--- a/ARMeilleure/Instructions/InstEmitSystem32.cs
+++ b/ARMeilleure/Instructions/InstEmitSystem32.cs
@@ -17,7 +17,8 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                throw new NotImplementedException($"Unknown MRC Coprocessor ID 0x{op.Coproc:X16} at 0x{op.Address:X16}.");
+                InstEmit.Und(context);
+                return;
             }
 
             if (op.Opc1 != 0)
@@ -70,7 +71,8 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                throw new NotImplementedException($"Unknown MRC Coprocessor ID 0x{op.Coproc:X16} at 0x{op.Address:X16}.");
+                InstEmit.Und(context);
+                return;
             }
 
             if (op.Opc1 != 0)
@@ -119,7 +121,8 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                throw new NotImplementedException($"Unknown MRC Coprocessor ID 0x{op.Coproc:X16} at 0x{op.Address:X16}.");
+                InstEmit.Und(context);
+                return;
             }
 
             var opc = op.MrrcOp;


### PR DESCRIPTION
…d of throw on invalid sysreg coprocessor (#964)

* Don't decode blocks in invalid memory locations.

* Emit undefined instruction on invalid coprocessor

...rather than throwing.

* Call undefined instruction directly.